### PR TITLE
Solving the problem with os.path.join on windows

### DIFF
--- a/src/osmdiff/augmenteddiff.py
+++ b/src/osmdiff/augmenteddiff.py
@@ -1,9 +1,9 @@
-import os
 from xml.etree import cElementTree
 
 import dateutil.parser
 import requests
 
+from join_url import join_url
 from .osm import OSMObject
 
 OVERPASS_URL = "http://overpass-api.de/api"
@@ -49,7 +49,7 @@ class AugmentedDiff(object):
 
     def get_state(self):
         """Get the current state from the OSM API"""
-        state_url = os.path.join(self.base_url, "augmented_diff_status")
+        state_url = join_url(self.base_url, "augmented_diff_status")
         if self.debug:
             print("getting state from", state_url)
         response = requests.get(state_url, timeout=5)

--- a/src/osmdiff/join_url.py
+++ b/src/osmdiff/join_url.py
@@ -1,0 +1,6 @@
+def join_url(*tuple):
+    temp = ""
+    for i in tuple:
+        temp = temp + '/' + i
+    temp = temp[1:]
+    return temp

--- a/src/osmdiff/osmchange.py
+++ b/src/osmdiff/osmchange.py
@@ -1,9 +1,9 @@
-import os
 from gzip import GzipFile
 from xml.etree import ElementTree
 
 import requests
 
+from join_url import join_url
 from osmdiff.osm import OSMObject
 
 REPLICATION_URL = "https://planet.openstreetmap.org/replication"
@@ -32,7 +32,7 @@ class OSMChange(object):
 
     def get_state(self):
         """Get the current state from the OSM API"""
-        state_url = os.path.join(self.base_url, self._frequency, "state.txt")
+        state_url = join_url(self.base_url, self._frequency, "state.txt")
         response = requests.get(state_url, timeout=5)
         if response.status_code != 200:
             return False
@@ -45,7 +45,7 @@ class OSMChange(object):
 
     def _build_sequence_url(self):
         seqno = str(self._sequence_number).zfill(9)
-        url = os.path.join(
+        url = join_url(
             self.base_url,
             self._frequency,
             seqno[:3],


### PR DESCRIPTION
Windows uses a different character in file paths than `/` in the url. The simplest solution was to write a function that concatenates the url together.