### PR TITLE
Fix a bug that caused incorrect data.

### DIFF
--- a/src/osmdiff/osmchange.py
+++ b/src/osmdiff/osmchange.py
@@ -35,7 +35,7 @@ class OSMChange(object):
         self.delete = []
         if file:
             with open(file, "r") as fh:
-                xml = ElementTree.iterparse(fh, events=("start", "end"))
+                xml = ElementTree.iterparse(fh)
                 self._parse_xml(xml)
         else:
             self._frequency = frequency
@@ -98,7 +98,7 @@ class OSMChange(object):
             if r.status_code != 200:
                 return r.status_code
             gzfile = GzipFile(fileobj=r.raw)
-            xml = ElementTree.iterparse(gzfile, events=("start", "end"))
+            xml = ElementTree.iterparse(gzfile)
             self._parse_xml(xml)
             return r.status_code
         except ConnectionError:
@@ -136,7 +136,7 @@ class OSMChange(object):
         :rtype: OSMChange
         """
         with open(path, "r") as fh:
-            xml = ElementTree.iterparse(fh, events=("start", "end"))
+            xml = ElementTree.iterparse(fh)
             return cls.from_xml(xml)
 
     @property

--- a/src/osmdiff/osmchange.py
+++ b/src/osmdiff/osmchange.py
@@ -34,7 +34,7 @@ class OSMChange(object):
         self.modify = []
         self.delete = []
         if file:
-            with open(file, "r") as fh:
+            with open(file, "r", encoding="utf-8") as fh:
                 xml = ElementTree.iterparse(fh)
                 self._parse_xml(xml)
         else:
@@ -135,7 +135,7 @@ class OSMChange(object):
         :return: OSMChange object
         :rtype: OSMChange
         """
-        with open(path, "r") as fh:
+        with open(path, "r", encoding="utf-8") as fh:
             xml = ElementTree.iterparse(fh)
             return cls.from_xml(xml)
 

--- a/tests/test_osmchange.py
+++ b/tests/test_osmchange.py
@@ -28,13 +28,13 @@ class TestOSMChange:
     def test_read_changeset_from_xml_file(self, osmchange_file_path):
         "Test initializing from an XML object"
         osmchange = OSMChange.from_xml_file(osmchange_file_path)
-        assert len(osmchange.create) == 1004
-        assert len(osmchange.modify) == 585
-        assert len(osmchange.delete) == 3800
+        assert len(osmchange.create) == 831
+        assert len(osmchange.modify) == 368
+        assert len(osmchange.delete) == 3552
         nodes_created = [o for o in osmchange.create if isinstance(o, Node)]
         ways_created = [o for o in osmchange.create if isinstance(o, Way)]
         rels_created = [o for o in osmchange.create if isinstance(o, Relation)]
-        assert len(nodes_created) == 858
-        assert len(ways_created) == 146
+        assert len(nodes_created) == 699
+        assert len(ways_created) == 132
         assert len(rels_created) == 0
         assert len(nodes_created + ways_created + rels_created) == len(osmchange.create)


### PR DESCRIPTION
The "start" event of XML parser generated incomplete data. Remove it, and let the XML parser only handle the "end" event.